### PR TITLE
infra: Add pull request presubmit checks, continuous `main` checks

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -11,3 +11,12 @@ build:macos --workspace_status_command=infra/get_workspace_status
 
 test --test_summary=testcase
 test --test_output=errors
+
+# These settings should be enabled whenever bazel is running in an automated
+# context
+build:noninteractive --color=yes
+build:noninteractive --curses=no
+build:noninteractive --show_timestamps
+build:noninteractive --announce_rc
+build:noninteractive --test_output=summary
+build:noninteractive --keep_going

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,34 @@
+# Postsubmit checks that run on the `main` branch after merge.
+name: "main"
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}.${{ github.ref }}
+
+jobs:
+  bazel-builder:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: run all tests
+        run: |
+          bazel test --config=noninteractive //...
+
+  golang-builder:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: build all
+        run: |
+          go build ./...
+      - name: run all tests
+        run: |
+          go test ./...

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -1,0 +1,38 @@
+# Presubmit checks for PRs
+name: "presubmit"
+
+on:
+  # Trigger on pull request rather than push, so that we can control whether
+  # checks are run on a given PR (allowing checks to run automatically on PR
+  # updates from third parties can be a security issue).
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}.${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bazel-builder:
+    # TODO(scott): Move to CI runners
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: run all tests
+        run: |
+          bazel test --config=noninteractive //...
+
+  golang-builder:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: build all
+        run: |
+          go build ./...
+      - name: run all tests
+        run: |
+          go test ./...


### PR DESCRIPTION
This change adds a Github workflow to run `go test ./...` and `bazel test //...` on each commit to `main` and `release` branch (should any exist) as well as PR reviews. A bazel config is created to customize bazel's behavior:
* keep_going (run all tests possible, even if build fails)
* UI conveniences (show timestamps, no curses, etc.)

The first iteration of these checks are basic actions that don't use our custom CI runners or RBE clusters, both of which can be added/enabled in future changes. As such, some amount of extra effort is taken to preserve bazel's local cache as much as possible, to speed up checks.

Bug: linear/CUS-345