### PR TITLE
automation: Add back Golang builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,25 @@ env:
   OPAL_RPC_CREDENTIALS: ${{ secrets.OPAL_RPC_CREDENTIALS }}
 
 jobs:
-  test-matrix:
+  bazel-builder:
+    runs-on:
+      - self-hosted
+      - os=linux
+      - arch=x64
+      - os_distribution=debian
+      - os_version=12
+      - revision=d04e89854b3931f4aaced77aa3a2fcad5834b3a6
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run all tests
+        run: |
+          # TODO(CUS-345): Enable remote execution
+          bazel test --config=noninteractive //...
+
+  golang-builder:
     runs-on:
       - self-hosted
       - "os=${{ matrix.os }}"
@@ -50,7 +68,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Test with Bazel
+      - name: Run all tests
         run: |
           # TODO(CUS-345): Enable remote execution
-          bazel test --config=noninteractive //...
+          bazel run --config=noninteractive @rules_go//go -- test ./...
+          bazel run --config=noninteractive @rules_go//go -- clean -cache -modcache

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -18,7 +18,25 @@ env:
   OPAL_RPC_CREDENTIALS: ${{ secrets.OPAL_RPC_CREDENTIALS }}
 
 jobs:
-  test-matrix:
+  bazel-builder:
+    runs-on:
+      - self-hosted
+      - os=linux
+      - arch=x64
+      - os_distribution=debian
+      - os_version=12
+      - revision=d04e89854b3931f4aaced77aa3a2fcad5834b3a6
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run all tests
+        run: |
+          # TODO(CUS-345): Enable remote execution
+          bazel test --config=noninteractive //...
+
+  golang-builder:
     runs-on:
       - self-hosted
       - "os=${{ matrix.os }}"
@@ -52,7 +70,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Test with Bazel
+      - name: Run all tests
         run: |
           # TODO(CUS-345): Enable remote execution
-          bazel test --config=noninteractive //...
+          bazel run --config=noninteractive @rules_go//go -- test ./...
+          bazel run --config=noninteractive @rules_go//go -- clean -cache -modcache


### PR DESCRIPTION
This change adds back builds using the Go toolchain, which can be downloaded and run via `bazel run`. Obtaining the Go toolchain this way saves us from having to install it on the self-hosted runners directly, and keeps the toolchain used in sync with the one used by bazel automatically.

The matrix builds are moved to using the Go toolchain, and building using bazel is done only with Linux. The rationale is:
* building on all platforms is useful for test coverage, and need only be done using either build system, but not necessarily both
* third parties are more likely to build the project using the Go tooling
* we intend to ship bazel-built binaries, so we need at least one build using bazel to protect the release builds

Bug: CUS-345