### PR TITLE
release: Fix `version` input substitution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: release
         run: |
-          infra/release.sh "${{ github.events.inputs.version }}"
+          infra/release.sh "${{ inputs.version }}"
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This change attempts to fix an issue with the release workflow where the input parameter is not correctly supplied to the release script.

The new substitution matches what is in documented examples [here](https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#example-of-onworkflow_dispatchinputs).

Tested: no