### PR TITLE
buildstamp: Fix "official" build stamping

### DIFF
--- a/internal/buildstamp/buildstamp.go
+++ b/internal/buildstamp/buildstamp.go
@@ -5,6 +5,7 @@ package buildstamp
 
 import (
 	"fmt"
+	"regexp"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -22,9 +23,8 @@ type Vars struct {
 const (
 	unknown = "<unknown>"
 
-	gitStatusClean    = "clean"
-	gitStatusDirty    = "modified"
-	gitOfficialBranch = "master"
+	gitStatusClean = "clean"
+	gitStatusDirty = "modified"
 )
 
 var (
@@ -35,6 +35,8 @@ var (
 
 	Values      Vars
 	emptyValues Vars
+
+	gitOfficialBranchRe = regexp.MustCompile(`main|release/v[0-9]+\.[0-9]+`)
 )
 
 func init() {
@@ -78,7 +80,7 @@ func init() {
 		Values.SourceBranch = gitBranch
 		Values.SourceRevision = gitSha
 		Values.IsClean = gitSourceTreeStatus == gitStatusClean
-		Values.IsOfficial = gitSourceTreeStatus == gitStatusClean && gitBranch == gitOfficialBranch
+		Values.IsOfficial = gitSourceTreeStatus == gitStatusClean && gitOfficialBranchRe.Match([]byte(gitBranch))
 
 		if ts, err := strconv.ParseInt(buildTimestamp, 10, 64); err == nil {
 			Values.BuildTimestamp = time.Unix(ts, 0)


### PR DESCRIPTION
This change fixes the logic for "official build" labeling in buildstamp logic. Before this change, only builds from the branch `master` were official; this was erroneous since this repo uses `main` as the trunk branch name.

This change validates the branch name against `main` and release branch patterns using a regexp, since technically official builds could come from release branches as well.

Tested: Created a temp local branch matching the release branch pattern, and checked that a build was marked official:

```
[blackbird | ~/dev/engflow.com/auth] (release/v0.0)
scott-> bazel run --stamp //cmd/engflow_auth -- version
INFO: Writing tracer profile to '/home/scott/.cache/bazel/_bazel_scott/b3a8ca38e37ded8f1e329b8939d3f3df/command.profile.gz'
INFO: Analyzed target //cmd/engflow_auth:engflow_auth (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //cmd/engflow_auth:engflow_auth up-to-date:
  bazel-bin/cmd/engflow_auth/engflow_auth_/engflow_auth
INFO: Elapsed time: 0.458s, Critical Path: 0.22s
INFO: 4 processes: 1 internal, 3 linux-sandbox.
INFO: Build completed successfully, 4 total actions
INFO: Running command line: bazel-bin/cmd/engflow_auth/engflow_auth_/engflow_auth version
build time: 2024-07-23 13:33:52 -0400 EDT
official build: true
build branch: release/v0.0
build revision: 742a795ba209ebdff9d3ce70d7ecdd727f3ea3de
clean build: true
```

Bug: linear/CUS-358