### PR TITLE
engflow_auth: Migrate to CLI library

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,6 +18,7 @@ use_repo(
     "com_github_golang_jwt_jwt_v5",
     "com_github_google_uuid",
     "com_github_stretchr_testify",
+    "com_github_urfave_cli_v2",
     "com_github_zalando_go_keyring",
     "org_golang_x_oauth2",
 )

--- a/cmd/engflow_auth/BUILD
+++ b/cmd/engflow_auth/BUILD
@@ -12,8 +12,9 @@ go_library(
         "//internal/buildstamp",
         "//internal/oauthdevice",
         "//internal/oauthtoken",
-        "@com_github_engflow_credential_helper_go//:go_default_library",
-        "@org_golang_x_oauth2//:go_default_library",
+        "@com_github_engflow_credential_helper_go//:credential-helper-go",
+        "@com_github_urfave_cli_v2//:cli",
+        "@org_golang_x_oauth2//:oauth2",
     ],
 )
 
@@ -32,8 +33,8 @@ go_test(
         "//internal/browser",
         "//internal/oauthdevice",
         "//internal/oauthtoken",
-        "@com_github_stretchr_testify//assert:go_default_library",
-        "@org_golang_x_oauth2//:go_default_library",
+        "@com_github_stretchr_testify//assert",
+        "@org_golang_x_oauth2//:oauth2",
     ],
 )
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.9.0
+	github.com/urfave/cli/v2 v2.27.2
 	github.com/zalando/go-keyring v0.2.5
 	golang.org/x/oauth2 v0.20.0
 )
@@ -19,7 +20,6 @@ require (
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/urfave/cli/v2 v2.27.2 // indirect
 	github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/autherr/BUILD
+++ b/internal/autherr/BUILD
@@ -1,8 +1,15 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "autherr",
     srcs = ["coded_error.go"],
     importpath = "github.com/EngFlow/auth/internal/autherr",
     visibility = ["//:__subpackages__"],
+)
+
+go_test(
+    name = "autherr_test",
+    srcs = ["coded_error_test.go"],
+    embed = [":autherr"],
+    deps = ["@com_github_urfave_cli_v2//:cli"],
 )

--- a/internal/autherr/coded_error.go
+++ b/internal/autherr/coded_error.go
@@ -28,6 +28,10 @@ func (e *CodedError) Error() string {
 	return e.Err.Error()
 }
 
+func (e *CodedError) ExitCode() int {
+	return e.Code
+}
+
 func CodedErrorf(code int, format string, args ...any) error {
 	return &CodedError{
 		Code: code,

--- a/internal/autherr/coded_error_test.go
+++ b/internal/autherr/coded_error_test.go
@@ -1,0 +1,7 @@
+package autherr
+
+import (
+	"github.com/urfave/cli/v2"
+)
+
+var _ cli.ExitCoder = (*CodedError)(nil)

--- a/internal/oauthdevice/BUILD
+++ b/internal/oauthdevice/BUILD
@@ -5,5 +5,5 @@ go_library(
     srcs = ["authenticator.go"],
     importpath = "github.com/EngFlow/auth/internal/oauthdevice",
     visibility = ["//:__subpackages__"],
-    deps = ["@org_golang_x_oauth2//:go_default_library"],
+    deps = ["@org_golang_x_oauth2//:oauth2"],
 )

--- a/internal/oauthtoken/BUILD
+++ b/internal/oauthtoken/BUILD
@@ -13,9 +13,9 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//internal/autherr",
-        "@com_github_golang_jwt_jwt_v5//:go_default_library",
-        "@com_github_zalando_go_keyring//:go_default_library",
-        "@org_golang_x_oauth2//:go_default_library",
+        "@com_github_golang_jwt_jwt_v5//:jwt",
+        "@com_github_zalando_go_keyring//:go-keyring",
+        "@org_golang_x_oauth2//:oauth2",
     ],
 )
 
@@ -29,11 +29,11 @@ go_test(
     embed = [":oauthtoken"],
     deps = [
         "//internal/autherr",
-        "@com_github_golang_jwt_jwt_v5//:go_default_library",
-        "@com_github_google_uuid//:go_default_library",
-        "@com_github_stretchr_testify//assert:go_default_library",
-        "@com_github_stretchr_testify//require:go_default_library",
-        "@com_github_zalando_go_keyring//:go_default_library",
-        "@org_golang_x_oauth2//:go_default_library",
+        "@com_github_golang_jwt_jwt_v5//:jwt",
+        "@com_github_google_uuid//:uuid",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@com_github_zalando_go_keyring//:go-keyring",
+        "@org_golang_x_oauth2//:oauth2",
     ],
 )


### PR DESCRIPTION
This change moves CLI parsing into urfave/cli/v2, so that we can easily add more subcommands without incrementally also writing our own CLI parser. The app is now split into two objects:

* `appState`, which contains injected dependencies that commands can use to interact with the various subsystems
* `cli.App`, which takes care of the CLI parsing logic. Each leaf subcommand has its logic implemented as a method of `appState`.

This change requires the following migrations:

* `rootCmd` type renamed to `appState`, since the former no longer does any CLI arg parsing
* methods of `appState` are now integrated with `cli.App`, as they can be used as Actions on subcommands:
  * they now take a `*cli.Context` as a parameter
  * they read from/write to Readers/Writers found on the `*cli.Context`, rather than those on the `appState` (which are now removed)
* help text is now printed on stdout rather than stderr (default behavior of `cli.App`)
* `autherr.CodedError` implements `cli.ExitCoder` (it may be possible to remove CodedError in favor of `cli.Exit()` in the future)

Tested:
* Because main's tests are shimming at the level of os.Args/stdin/stdout/stderr, we can have high confidence that the unit tests passing means that behavior of the CLI is not meaningfully changed
* Manually tested `version`, `help`, `login` subcommands and did build on Kyanite using new binary