### PR TITLE
infra: Add copyright headers check, copyright headers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,17 @@
+# Copyright 2024 EngFlow Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Postsubmit checks that run on the `main` branch after merge.
 name: "main"
 
@@ -73,3 +87,20 @@ jobs:
           # TODO(CUS-345): Enable remote execution
           bazel run --config=noninteractive @rules_go//go -- test ./...
           bazel run --config=noninteractive @rules_go//go -- clean -cache -modcache
+
+  copyright-headers-check:
+    runs-on:
+      - self-hosted
+      - os=linux
+      - arch=x64
+      - os_distribution=debian
+      - os_version=12
+      - revision=d04e89854b3931f4aaced77aa3a2fcad5834b3a6
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check copyright headers
+        run: |
+          bazel run --config=noninteractive //infra/internal/check_copyright_headers

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -1,3 +1,17 @@
+# Copyright 2024 EngFlow Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Presubmit checks for PRs
 name: "presubmit"
 
@@ -75,3 +89,20 @@ jobs:
           # TODO(CUS-345): Enable remote execution
           bazel run --config=noninteractive @rules_go//go -- test ./...
           bazel run --config=noninteractive @rules_go//go -- clean -cache -modcache
+
+  copyright-headers-check:
+    runs-on:
+      - self-hosted
+      - os=linux
+      - arch=x64
+      - os_distribution=debian
+      - os_version=12
+      - revision=d04e89854b3931f4aaced77aa3a2fcad5834b3a6
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check copyright headers
+        run: |
+          bazel run --config=noninteractive //infra/internal/check_copyright_headers

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,17 @@
+# Copyright 2024 EngFlow Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: "release"
 
 on:

--- a/cmd/engflow_auth/main.go
+++ b/cmd/engflow_auth/main.go
@@ -1,3 +1,17 @@
+// Copyright 2024 EngFlow Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/cmd/engflow_auth/main_test.go
+++ b/cmd/engflow_auth/main_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 EngFlow Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/infra/get_workspace_status
+++ b/infra/get_workspace_status
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Copyright 2024 EngFlow Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # The variables defined here are available not only in BES logs, but also for
 # stamping into built binaries (version information, etc.). Removing vars or
 # changing var names may break these version stamping libraries; if this script

--- a/infra/internal/check_copyright_headers/BUILD
+++ b/infra/internal/check_copyright_headers/BUILD
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "check_copyright_headers_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/EngFlow/auth/infra/internal/check_copyright_headers",
+    visibility = ["//infra:__subpackages__"],
+)
+
+go_binary(
+    name = "check_copyright_headers",
+    embed = [":check_copyright_headers_lib"],
+    visibility = ["//infra:__subpackages__"],
+)

--- a/infra/internal/check_copyright_headers/main.go
+++ b/infra/internal/check_copyright_headers/main.go
@@ -1,0 +1,126 @@
+// Copyright 2024 EngFlow Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var (
+	skipRegexps = []*regexp.Regexp{
+		regexp.MustCompile(`^go\.mod$`),
+		regexp.MustCompile(`^go\.sum$`),
+		regexp.MustCompile(`^LICENSE$`),
+		regexp.MustCompile(`^MODULE\.bazel\.lock$`),
+		regexp.MustCompile(`^MODULE\.bazel$`),
+		regexp.MustCompile(`^README.md$`),
+		regexp.MustCompile(`^WORKSPACE$`),
+		regexp.MustCompile(`(/|^)BUILD$`),
+		regexp.MustCompile(`^\.bazelrc$`),
+		regexp.MustCompile(`^\.gitignore$`),
+		regexp.MustCompile(`\.bzl$`),
+	}
+	copyrightRegexp = regexp.MustCompile(`^(#|//) Copyright [0-9-]+ EngFlow Inc\.`)
+)
+
+type checkerFunc func(string) bool
+
+// listSourceFiles returns the list of files that git cares about in the current
+// commit.
+func listSourceFiles(repoRoot string) ([]string, error) {
+	cmd := exec.Command("git", "ls-tree", "-r", "--name-only", "HEAD")
+	cmd.Dir = repoRoot
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("`git ls-tree` failed: %w", err)
+	}
+	return strings.Split(strings.TrimSpace(string(output)), "\n"), nil
+}
+
+// filterStrings returns strings in `universe` that don't match any regexps in
+// `remove`.
+func filterStrings(universe []string, remove []*regexp.Regexp) []string {
+	var filtered []string
+nextStr:
+	for _, s := range universe {
+		for _, r := range remove {
+			if r.MatchString(s) {
+				continue nextStr
+			}
+		}
+		filtered = append(filtered, s)
+	}
+	return filtered
+}
+
+// checkCopyright runs the supplied checker on each line of the file, returning
+// an error if the checker never returns true.
+func checkCopyright(path string, checker checkerFunc) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		if checker(scanner.Text()) {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s: missing copyright header", path)
+}
+
+func run() error {
+	workspaceRoot := os.Getenv("BUILD_WORKSPACE_DIRECTORY")
+	if workspaceRoot == "" {
+		return fmt.Errorf("$BUILD_WORKSPACE_DIRECTORY is not set; please run this script via `bazel run`")
+	}
+	srcFiles, err := listSourceFiles(workspaceRoot)
+	if err != nil {
+		return err
+	}
+
+	srcFiles = filterStrings(srcFiles, skipRegexps)
+
+	var errs []error
+	for _, f := range srcFiles {
+		if err := checkCopyright(filepath.Join(workspaceRoot, f), copyrightRegexp.MatchString); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	sort.Slice(errs, func(i, j int) bool { return errs[i].Error() < errs[j].Error() })
+	return fmt.Errorf("copyright header check failed:\n%v", errors.Join(errs...))
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/infra/release.sh
+++ b/infra/release.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
+# Copyright 2024 EngFlow Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -o nounset -o pipefail -o errexit
 [[ "${SCRIPT_DEBUG:-"off"}" == "on" ]] && set -o xtrace
 

--- a/internal/autherr/coded_error.go
+++ b/internal/autherr/coded_error.go
@@ -1,3 +1,17 @@
+// Copyright 2024 EngFlow Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package autherr
 
 import (

--- a/internal/autherr/coded_error_test.go
+++ b/internal/autherr/coded_error_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 EngFlow Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package autherr
 
 import (

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -1,3 +1,17 @@
+// Copyright 2024 EngFlow Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package browser
 
 import (

--- a/internal/buildstamp/buildstamp.go
+++ b/internal/buildstamp/buildstamp.go
@@ -1,3 +1,17 @@
+// Copyright 2024 EngFlow Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package buildstamp exports build metadata values that may be optionally set
 // by the build system, for runtime inspection. The primary usecase is for
 // identifying application provenance (e.g. what branch, user built the code).

--- a/internal/oauthdevice/authenticator.go
+++ b/internal/oauthdevice/authenticator.go
@@ -1,3 +1,17 @@
+// Copyright 2024 EngFlow Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package oauthdevice
 
 import (

--- a/internal/oauthtoken/cache_alert.go
+++ b/internal/oauthtoken/cache_alert.go
@@ -1,3 +1,17 @@
+// Copyright 2024 EngFlow Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package oauthtoken
 
 import (

--- a/internal/oauthtoken/cache_alert_test.go
+++ b/internal/oauthtoken/cache_alert_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 EngFlow Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package oauthtoken
 
 import (

--- a/internal/oauthtoken/debug.go
+++ b/internal/oauthtoken/debug.go
@@ -1,3 +1,17 @@
+// Copyright 2024 EngFlow Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package oauthtoken
 
 import (

--- a/internal/oauthtoken/file.go
+++ b/internal/oauthtoken/file.go
@@ -1,3 +1,17 @@
+// Copyright 2024 EngFlow Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package oauthtoken
 
 import (

--- a/internal/oauthtoken/file_test.go
+++ b/internal/oauthtoken/file_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 EngFlow Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package oauthtoken
 
 import (

--- a/internal/oauthtoken/keyring.go
+++ b/internal/oauthtoken/keyring.go
@@ -1,3 +1,17 @@
+// Copyright 2024 EngFlow Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package oauthtoken
 
 import (

--- a/internal/oauthtoken/keyring_test.go
+++ b/internal/oauthtoken/keyring_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 EngFlow Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package oauthtoken
 
 import (

--- a/internal/oauthtoken/load_storer.go
+++ b/internal/oauthtoken/load_storer.go
@@ -1,3 +1,17 @@
+// Copyright 2024 EngFlow Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package oauthtoken
 
 import (


### PR DESCRIPTION
This change adds:

* a Go tool to check for copyright headers
* a Github job to run the check in presubmit and postsubmit
* copyright headers to all files, to satisfy the check

Because this check necessarily depends on all source files, it can't be implemented as a bazel test, so it is instead designed to be invoked via `bazel run` (depends on an environment var that locates the workspace root). Go was chosen over bash to avoid complicated pipelines and array/associative array bash syntax.

Tested: Wrote the tool first; it identified all the source files in the repo, which were resolved either by adding a header, or by adding an exception inside the `generatedFiles` var.