### PR TITLE
release: Stamp binaries with released version

### DIFF
--- a/infra/get_workspace_status
+++ b/infra/get_workspace_status
@@ -23,6 +23,7 @@
 
 echo BUILD_SCM_BRANCH $(git rev-parse --abbrev-ref HEAD)
 echo BUILD_SCM_REVISION $(git rev-parse --verify HEAD)
+echo STABLE_BUILD_RELEASE_VERSION ${BUILD_RELEASE_VERSION}
 
 git diff-index --quiet HEAD --
 if [[ $? == 0 ]]; then

--- a/infra/release.sh
+++ b/infra/release.sh
@@ -78,7 +78,8 @@ echo "[FINISH] Release branch checks"
 
 # Build release artifacts
 echo "[START]  Building artifacts"
-bazel build \
+BUILD_RELEASE_VERSION="${RELEASE_VERSION}" \
+    bazel build \
     --config=release \
     -- \
     //:release_artifacts

--- a/internal/buildstamp/BUILD
+++ b/internal/buildstamp/BUILD
@@ -9,6 +9,7 @@ go_library(
         # These vars are populated by `infra/get_workspace_status` and are set
         # when the `--stamp` flag is passed to bazel. See
         # https://bazel.build/docs/user-manual#workspace-status for more info.
+        "releaseVersion": "{STABLE_BUILD_RELEASE_VERSION}",
         "gitBranch": "{BUILD_SCM_BRANCH}",
         "gitSha": "{BUILD_SCM_REVISION}",
         "gitSourceTreeStatus": "{BUILD_SCM_STATUS}",

--- a/internal/buildstamp/buildstamp.go
+++ b/internal/buildstamp/buildstamp.go
@@ -27,6 +27,7 @@ import (
 )
 
 type Vars struct {
+	ReleaseVersion string
 	SourceBranch   string
 	SourceRevision string
 	IsClean        bool
@@ -42,6 +43,7 @@ const (
 )
 
 var (
+	releaseVersion      = unknown
 	gitBranch           = unknown
 	gitSha              = unknown
 	gitSourceTreeStatus = unknown
@@ -91,6 +93,7 @@ func init() {
 		}
 		// Assume stamping is enabled, and initialize Vars accordingly.
 
+		Values.ReleaseVersion = releaseVersion
 		Values.SourceBranch = gitBranch
 		Values.SourceRevision = gitSha
 		Values.IsClean = gitSourceTreeStatus == gitStatusClean
@@ -116,6 +119,9 @@ func (v Vars) String() string {
 		return "build metadata is unavailable (build with bazel's `--stamp` flag to enable)"
 	}
 	var sb strings.Builder
+	if v.ReleaseVersion != unknown {
+		fmt.Fprintf(&sb, "release version: %v\n", v.ReleaseVersion)
+	}
 	fmt.Fprintf(&sb, "build time: %v\n", v.BuildTimestamp)
 	fmt.Fprintf(&sb, "official build: %v\n", v.IsOfficial)
 	fmt.Fprintf(&sb, "build branch: %s\n", v.SourceBranch)


### PR DESCRIPTION
Stamping the release version into binaries is necessary for both bug
reporting and reporting of client versions during auth, but is
challenging:
* logic to get the latest release tag info from git can be error-prone,
  due to the number of cases to handle (release off of main, off of
  release branch, etc.)
* tag is created last (so that we can be confident release will be
  successful before creating the tag) and isn't even present in git info
  during the build

Since we know the release version at the time of release, and we already
have a way to plumb buildstamp variables, this change allows the version
to be plumbed in via an environment variable:

* `get_workspace_status` will set a buildstamp var based on the
  environment variable's value
* the buildstamp library will read this var, and conditionally print the
  release version based on its value

Tested:
* negative case:

  ```
  scott-> bazel run --stamp //cmd/engflow_auth -- version
  build time: 2024-07-31 15:38:03 -0400 EDT
  official build: false
  build branch: scott/release_stamped_version
  build revision: 56612bc4adfbb777a76af06f98819ce00efd5808
  clean build: true
  ```

* positive case:

  ```
  scott-> BUILD_RELEASE_VERSION=foobar bazel run --stamp //cmd/engflow_auth -- version
  release version: foobar
  build time: 2024-07-31 15:36:30 -0400 EDT
  official build: false
  build branch: scott/release_stamped_version
  build revision: 56612bc4adfbb777a76af06f98819ce00efd5808
  clean build: true
  ```