### PR TITLE
CUS-384: remove context parameter from LoadStorer interface

### DIFF
--- a/internal/oauthtoken/cache_alert_test.go
+++ b/internal/oauthtoken/cache_alert_test.go
@@ -16,7 +16,6 @@ package oauthtoken
 
 import (
 	"bytes"
-	"context"
 	"testing"
 	"time"
 
@@ -45,7 +44,6 @@ func mustTokenForSubject(t *testing.T, name string) string {
 }
 
 func TestTokenCacheWarning(t *testing.T) {
-	ctx := context.Background()
 	var testStderr bytes.Buffer
 	tokenStore := NewCacheAlert(NewFakeTokenStore(), &testStderr)
 
@@ -59,16 +57,16 @@ func TestTokenCacheWarning(t *testing.T) {
 	}
 
 	// Storing an initial token should produce no warning
-	err := tokenStore.Store(ctx, "default", testTokenAlice)
+	err := tokenStore.Store("default", testTokenAlice)
 	require.NoError(t, err)
 	assert.Len(t, testStderr.String(), 0)
-	err = tokenStore.Store(ctx, "special", testTokenAlice)
+	err = tokenStore.Store("special", testTokenAlice)
 	require.NoError(t, err)
 	assert.Len(t, testStderr.String(), 0)
 
 	// Storing a token with a different principal for a given cluster should
 	// produce a warning
-	err = tokenStore.Store(ctx, "default", testTokenBob)
+	err = tokenStore.Store("default", testTokenBob)
 	require.NoError(t, err)
 	assert.Contains(t, testStderr.String(), "Login identity has changed")
 	assert.Contains(t, testStderr.String(), "bazel shutdown")
@@ -76,7 +74,7 @@ func TestTokenCacheWarning(t *testing.T) {
 
 	// Storing a token with the same principal for a given cluster should
 	// produce no warning
-	err = tokenStore.Store(ctx, "special", testTokenAlice)
+	err = tokenStore.Store("special", testTokenAlice)
 	require.NoError(t, err)
 	assert.Len(t, testStderr.String(), 0)
 }

--- a/internal/oauthtoken/fake.go
+++ b/internal/oauthtoken/fake.go
@@ -15,7 +15,6 @@
 package oauthtoken
 
 import (
-	"context"
 	"fmt"
 
 	"golang.org/x/oauth2"
@@ -36,7 +35,7 @@ func NewFakeTokenStore() *FakeTokenStore {
 	}
 }
 
-func (f *FakeTokenStore) Load(ctx context.Context, cluster string) (*oauth2.Token, error) {
+func (f *FakeTokenStore) Load(cluster string) (*oauth2.Token, error) {
 	if f.LoadErr != nil {
 		return nil, f.LoadErr
 	}
@@ -47,7 +46,7 @@ func (f *FakeTokenStore) Load(ctx context.Context, cluster string) (*oauth2.Toke
 	return token, nil
 }
 
-func (f *FakeTokenStore) Store(ctx context.Context, cluster string, token *oauth2.Token) error {
+func (f *FakeTokenStore) Store(cluster string, token *oauth2.Token) error {
 	if f.StoreErr != nil {
 		return f.StoreErr
 	}
@@ -55,7 +54,7 @@ func (f *FakeTokenStore) Store(ctx context.Context, cluster string, token *oauth
 	return nil
 }
 
-func (f *FakeTokenStore) Delete(ctx context.Context, cluster string) error {
+func (f *FakeTokenStore) Delete(cluster string) error {
 	if f.DeleteErr != nil {
 		return f.DeleteErr
 	}

--- a/internal/oauthtoken/keyring.go
+++ b/internal/oauthtoken/keyring.go
@@ -15,7 +15,6 @@
 package oauthtoken
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -44,7 +43,7 @@ func NewKeyring() (LoadStorer, error) {
 	}, nil
 }
 
-func (f *Keyring) Load(ctx context.Context, cluster string) (*oauth2.Token, error) {
+func (f *Keyring) Load(cluster string) (*oauth2.Token, error) {
 	serviceName := f.secretServiceName(cluster)
 	contents, err := keyring.Get(serviceName, f.username)
 	if err != nil {
@@ -61,7 +60,7 @@ func (f *Keyring) Load(ctx context.Context, cluster string) (*oauth2.Token, erro
 	return parsed, nil
 }
 
-func (f *Keyring) Store(ctx context.Context, cluster string, token *oauth2.Token) error {
+func (f *Keyring) Store(cluster string, token *oauth2.Token) error {
 	serviceName := f.secretServiceName(cluster)
 	tokenStr, err := json.Marshal(token)
 	if err != nil {
@@ -76,7 +75,7 @@ func (f *Keyring) Store(ctx context.Context, cluster string, token *oauth2.Token
 	return nil
 }
 
-func (f *Keyring) Delete(ctx context.Context, cluster string) error {
+func (f *Keyring) Delete(cluster string) error {
 	serviceName := f.secretServiceName(cluster)
 	if err := keyring.Delete(serviceName, f.username); errors.Is(err, keyring.ErrNotFound) {
 		return nil

--- a/internal/oauthtoken/keyring_test.go
+++ b/internal/oauthtoken/keyring_test.go
@@ -15,7 +15,6 @@
 package oauthtoken
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -37,7 +36,6 @@ func init() {
 }
 
 func TestKeyringTokenRoundtrip(t *testing.T) {
-	ctx := context.Background()
 	testKeyring := &Keyring{
 		username: "jmcclane",
 	}
@@ -45,13 +43,13 @@ func TestKeyringTokenRoundtrip(t *testing.T) {
 	token := &oauth2.Token{
 		AccessToken: uuid.New().String(),
 	}
-	_, gotErr := testKeyring.Load(ctx, cluster)
+	_, gotErr := testKeyring.Load(cluster)
 	require.Equal(t, autherr.ReauthRequired(cluster), gotErr)
 
-	gotErr = testKeyring.Store(ctx, cluster, token)
+	gotErr = testKeyring.Store(cluster, token)
 	require.NoError(t, gotErr)
 
-	gotToken, gotErr := testKeyring.Load(ctx, cluster)
+	gotToken, gotErr := testKeyring.Load(cluster)
 	require.NoError(t, gotErr)
 	assert.Equal(t, gotToken, token)
 }
@@ -60,10 +58,9 @@ func TestKeyringLoadError(t *testing.T) {
 	wantErr := errors.New("load_error")
 	keyring.MockInitWithError(wantErr)
 	t.Cleanup(keyring.MockInit)
-	ctx := context.Background()
 	testKeyring := &Keyring{username: "jmcclane"}
 	cluster := "nakatomiplaza.cluster.engflow.com"
-	_, gotErr := testKeyring.Load(ctx, cluster)
+	_, gotErr := testKeyring.Load(cluster)
 	require.ErrorIs(t, gotErr, wantErr)
 	require.ErrorContains(t, gotErr, "failed to look up token")
 }
@@ -72,13 +69,12 @@ func TestKeyringStoreError(t *testing.T) {
 	wantErr := errors.New("store_error")
 	keyring.MockInitWithError(wantErr)
 	t.Cleanup(keyring.MockInit)
-	ctx := context.Background()
 	testKeyring := &Keyring{username: "jmcclane"}
 	cluster := "nakatomiplaza.cluster.engflow.com"
 	token := &oauth2.Token{
 		AccessToken: uuid.New().String(),
 	}
-	gotErr := testKeyring.Store(ctx, cluster, token)
+	gotErr := testKeyring.Store(cluster, token)
 	require.ErrorIs(t, gotErr, wantErr)
 	require.ErrorContains(t, gotErr, "failed to store token")
 }

--- a/internal/oauthtoken/load_storer.go
+++ b/internal/oauthtoken/load_storer.go
@@ -15,13 +15,11 @@
 package oauthtoken
 
 import (
-	"context"
-
 	"golang.org/x/oauth2"
 )
 
 type LoadStorer interface {
-	Load(context.Context, string) (*oauth2.Token, error)
-	Store(context.Context, string, *oauth2.Token) error
-	Delete(context.Context, string) error
+	Load(string) (*oauth2.Token, error)
+	Store(string, *oauth2.Token) error
+	Delete(string) error
 }


### PR DESCRIPTION
It's not used in any implementation, so let's simplify. It's unlikely
any implementation in the future will need to support cancellation.
