### PR TITLE
DeviceCode: Send `engflow_auth` version in requests

### DIFF
--- a/internal/auth/BUILD
+++ b/internal/auth/BUILD
@@ -8,6 +8,8 @@ go_library(
     deps = [
         "//internal/autherr",
         "//internal/browser",
+        "//internal/buildstamp",
+        "//internal/httputil",
         "@org_golang_x_oauth2//:oauth2",
     ],
 )
@@ -17,7 +19,6 @@ go_test(
     srcs = ["authenticator_test.go"],
     embed = [":auth"],
     deps = [
-        "//internal/browser",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//mock",
         "@org_golang_x_oauth2//:oauth2",

--- a/internal/httputil/BUILD
+++ b/internal/httputil/BUILD
@@ -1,0 +1,8 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "httputil",
+    srcs = ["header_transport.go"],
+    importpath = "github.com/EngFlow/auth/internal/httputil",
+    visibility = ["//:__subpackages__"],
+)

--- a/internal/httputil/header_transport.go
+++ b/internal/httputil/header_transport.go
@@ -1,0 +1,44 @@
+// Copyright 2024 EngFlow Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package httputil provides additional types/helpers for HTTP communication.
+package httputil
+
+import "net/http"
+
+// HeaderInsertingTransport wraps an http.RoundTripper and inserts headers into
+// the request before propagating it to the underlying implementation.
+type HeaderInsertingTransport struct {
+	// Transport is the underlying transport actually performing requests.
+	Transport http.RoundTripper
+	// Headers specify the headers to add on each request. These headers will
+	// override existing headers on the request with the same name; headers on
+	// the request not mentioned here are not modified.
+	Headers http.Header
+}
+
+func (t *HeaderInsertingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Clone the request so the original is not modified
+	req = req.Clone(req.Context())
+
+	for k := range t.Headers {
+		req.Header.Del(k)
+	}
+	for k, vals := range t.Headers {
+		for _, val := range vals {
+			req.Header.Add(k, val)
+		}
+	}
+	return t.Transport.RoundTrip(req)
+}


### PR DESCRIPTION
This change modifies the HTTP client used by the `DeviceCode` Authenticator implementation to send version information in each request.

The version info is sent in the `User-Agent` header, using the format:

    engflow_auth/vX.Y.Z

The version string is generated by the `buildstamp` library and is a semver string in a release binary, or a "pseudoversion" in a dev binary, similar go Go module pseudoversions.

Tested: 
* Added unit tests
* `bazel run //cmd/engflow_auth` against dev cluster fails (no buildstamp info)
* `bazel run --stamp //cmd/engflow_auth` against dev cluster succeeds

Bug: linear/CUS-387