### PR TITLE
oauthtoken: Clarify `LoadStorer` interface

### DIFF
--- a/internal/oauthtoken/cache_alert.go
+++ b/internal/oauthtoken/cache_alert.go
@@ -39,7 +39,7 @@ func NewCacheAlert(impl LoadStorer, stderr io.Writer) LoadStorer {
 
 func (a *CacheAlert) Store(cluster string, token *oauth2.Token) error {
 	oldToken, err := a.Load(cluster)
-	if err != nil || oldToken == nil {
+	if err != nil {
 		// Failed to fetch any sort of previous valid token. Defer to the
 		// wrapped implementation; we'll assume that the token didn't exist
 		// previously (and therefore no need to issue a warning).

--- a/internal/oauthtoken/keyring_test.go
+++ b/internal/oauthtoken/keyring_test.go
@@ -16,9 +16,9 @@ package oauthtoken
 
 import (
 	"errors"
+	"io/fs"
 	"testing"
 
-	"github.com/EngFlow/auth/internal/autherr"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -44,7 +44,7 @@ func TestKeyringTokenRoundtrip(t *testing.T) {
 		AccessToken: uuid.New().String(),
 	}
 	_, gotErr := testKeyring.Load(cluster)
-	require.Equal(t, autherr.ReauthRequired(cluster), gotErr)
+	require.ErrorIs(t, gotErr, fs.ErrNotExist)
 
 	gotErr = testKeyring.Store(cluster, token)
 	require.NoError(t, gotErr)

--- a/internal/oauthtoken/load_storer.go
+++ b/internal/oauthtoken/load_storer.go
@@ -18,8 +18,23 @@ import (
 	"golang.org/x/oauth2"
 )
 
+// LoadStorer provides access to a token via some backend implementation/policy.
 type LoadStorer interface {
-	Load(string) (*oauth2.Token, error)
-	Store(string, *oauth2.Token) error
+	// Load loads a token for a cluster, specified by hostname. It returns
+	// fs.ErrNotFound if the token isn't present, or an unspecified non-nil
+	// error for any other error conditions.
+	Load(cluster string) (*oauth2.Token, error)
+
+	// Store stores a token for a cluster, specified by hostname. It returns an
+	// unspecified non-nil error if the operation fails; in this case, the state
+	// of the token storage for the specified cluster is not specified (token
+	// storage for other clusters is unaffected).
+	Store(cluster string, token *oauth2.Token) error
+
+	// Delete deletes a token for a cluster, specified by hostname. It returns
+	// fs.ErrNotFound if there is currently no token stored for the specified
+	// cluster, or an unspecified non-nil error for any other error conditions
+	// (although the storage backend should make a best-effort attempt to delete
+	// the token).
 	Delete(string) error
 }


### PR DESCRIPTION
This change clarifies the contract of each method of `LoadStorer` - specifically, which errors are returned on what conditions. Existing implementations are brought into compliance with the described contract; `Keyring` now returns an error that can be compared to `fs.ErrNotExist` to check for failure due to token nonexistence.

Bug: linear/CUS-384