### PR TITLE
CUS-384: fix -store flag, make test less fake-reliant

### DIFF
--- a/cmd/engflow_auth/BUILD
+++ b/cmd/engflow_auth/BUILD
@@ -34,6 +34,7 @@ go_test(
         "//internal/oauthdevice",
         "//internal/oauthtoken",
         "@com_github_stretchr_testify//assert",
+        "@com_github_zalando_go_keyring//:go-keyring",
         "@org_golang_x_oauth2//:oauth2",
     ],
 )

--- a/cmd/engflow_auth/main_test.go
+++ b/cmd/engflow_auth/main_test.go
@@ -30,8 +30,14 @@ import (
 	"github.com/EngFlow/auth/internal/oauthdevice"
 	"github.com/EngFlow/auth/internal/oauthtoken"
 	"github.com/stretchr/testify/assert"
+	"github.com/zalando/go-keyring"
 	"golang.org/x/oauth2"
 )
+
+func init() {
+	// Tests should not interact with the user's real keyring.
+	keyring.MockInit()
+}
 
 func codedErrorContains(t *testing.T, gotErr error, code int, wantMsg string) bool {
 	t.Helper()
@@ -529,6 +535,7 @@ func TestRun(t *testing.T) {
 			stderr := bytes.NewBuffer(nil)
 
 			root := &appState{
+				userConfigDir: t.TempDir(),
 				browserOpener: tc.browserOpener,
 				authenticator: tc.authenticator,
 				tokenStore:    tc.tokenStore,
@@ -538,9 +545,6 @@ func TestRun(t *testing.T) {
 			}
 			if root.authenticator == nil {
 				root.authenticator = &fakeAuth{}
-			}
-			if root.tokenStore == nil {
-				root.tokenStore = oauthtoken.NewFakeTokenStore()
 			}
 
 			app := makeApp(root)


### PR DESCRIPTION
In #37, we thought App.Before was called after subcommand flag parsing,
but it is not. This meant the -store flag did not work. We need the flags
to be parsed before we construct the object graph in appState.build.
Instead, call appState.build from the Command.Before hook.

Our tests in main_test.go should have caught this, but they fake
appState.tokenStore so the -store flag is ignored. This PR now makes
the test use the real LoadStorer implementations in most cases, but
calls keyring.MockInit ahead of time and uses a temporary user configuration
directory to avoid side effects.
