### PR TITLE
REC-67: CI: refactor login, logout scripts

### DIFF
--- a/infra/login.sh
+++ b/infra/login.sh
@@ -22,8 +22,17 @@ set -o nounset -o pipefail -o errexit
 [[ "${SCRIPT_DEBUG:-"off"}" == "on" ]] && set -o xtrace
 
 if [[ -z "${ARCH:-}" ]]; then
-  echo "ARCH not set"
-  exit 1
+  case "$(uname -m)" in
+  aarch64|arm64)
+    export ARCH=arm64
+    ;;
+  x86_64)
+    export ARCH=x64
+    ;;
+  *)
+    echo >&2 "ARCH not set, and 'uname -m' returned unknown value $(uname -m)"
+    exit 1
+  esac
 fi
 if [[ -z "${CLUSTER_HOST:-}" ]]; then
   echo "CLUSTER_HOST not set"
@@ -34,13 +43,25 @@ if [[ -z "${CRED_HELPER_TOKEN:-}" ]]; then
   exit 1
 fi
 if [[ -z "${OS:-}" ]]; then
-  echo "OS not set"
-  exit 1
+  case "$(uname)" in
+  Darwin)
+    export OS=macos
+    ;;
+  Linux)
+    export OS=linux
+    ;;
+  MSYS*)
+    export OS=windows
+    ;;
+  *)
+    echo >&2 "OS not set, and 'uname' returned unknown value $(uname)"
+    exit 1
+  esac
 fi
 
 # Download a recent version of engflow_auth to a local directory,
 # then use it to import the credential.
-readonly ENGFLOW_AUTH_VERSION=v0.0.6
+readonly ENGFLOW_AUTH_VERSION=v0.0.7
 readonly TOOLS_DIR=$(pwd)/_tools
 readonly ENGFLOW_AUTH_URL="https://github.com/EngFlow/auth/releases/download/${ENGFLOW_AUTH_VERSION}/engflow_auth_${OS}_${ARCH}"
 if [[ "${OS}" == "windows" ]]; then
@@ -52,7 +73,9 @@ else
   readonly ENGFLOW_AUTH_PATH="${TOOLS_DIR}/engflow_auth"
 fi
 mkdir -p "${TOOLS_DIR}"
-if ! curl --fail-with-body --location --output "${ENGFLOW_AUTH_PATH}" "${ENGFLOW_AUTH_URL}"; then
+HTTP_STATUS=$(curl --location --write-out "%{http_code}" --output "${ENGFLOW_AUTH_PATH}" "${ENGFLOW_AUTH_URL}")
+if [[ "${HTTP_STATUS}" != 200 ]]; then
+  echo "curl failed with status ${HTTP_STATUS}:" >&2
   cat "${ENGFLOW_AUTH_PATH}" >&2
   exit 1
 fi

--- a/infra/logout.sh
+++ b/infra/logout.sh
@@ -24,13 +24,9 @@ if [[ -z "${CLUSTER_HOST:-}" ]]; then
   echo "CLUSTER_HOST not set"
   exit 1
 fi
-if [[ -z "${OS:-}" ]]; then
-  echo "OS not set"
-  exit 1
-fi
 
 readonly TOOLS_DIR=$(pwd)/_tools
-if [[ "${OS}" == "windows" ]]; then
+if [[ -f "${TOOLS_DIR}/engflow_auth.exe" ]]; then
   readonly ENGFLOW_AUTH_PATH="${TOOLS_DIR}/engflow_auth.exe"
 else
   readonly ENGFLOW_AUTH_PATH="${TOOLS_DIR}/engflow_auth"


### PR DESCRIPTION
Allow OS and ARCH not to be set. It's kind of annoying to set these
in every workflow when they can be detected with uname.

When downloading engflow_auth, support old versions of curl that lack
the --fail-with-body flag. This is needed for Debian 11.
