### PR TITLE
REC-55: login.sh: upgrade to v0.0.8

### DIFF
--- a/infra/login.sh
+++ b/infra/login.sh
@@ -61,7 +61,7 @@ fi
 
 # Download a recent version of engflow_auth to a local directory,
 # then use it to import the credential.
-readonly ENGFLOW_AUTH_VERSION=v0.0.7
+readonly ENGFLOW_AUTH_VERSION=v0.0.8
 readonly TOOLS_DIR=$(pwd)/_tools
 readonly ENGFLOW_AUTH_URL="https://github.com/EngFlow/auth/releases/download/${ENGFLOW_AUTH_VERSION}/engflow_auth_${OS}_${ARCH}"
 if [[ "${OS}" == "windows" ]]; then


### PR DESCRIPTION
Before #53, I fixed a typo spotted by @minor-fixes without
manually testing it: the Linux build now runs on Debian 11.
That means the engflow_auth binary installed by login.sh
does not work because v0.0.7 was built on Debian 12.
We need v0.0.8 instead.
