### PR TITLE
REC-102: release: multiple fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: success()
         with:
+          name: linux
           path: _out
           if-no-files-found: error
           retention-days: 1
@@ -143,6 +144,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: success()
         with:
+          name: ${{ matrix.os }}
           path: _out
           if-no-files-found: error
           retention-days: 1

--- a/infra/release-build.sh
+++ b/infra/release-build.sh
@@ -106,5 +106,5 @@ trap uninstall_cert EXIT
 for target in "${TARGETS[@]}"; do
   target_file=$(bazel cquery --output=files "${target}")
   sign_and_notarize_binary "${target_file}"
-  cp "${target_file}" "_out/${target_file}${EXT}"
+  cp "${target_file}" "_out/$(basename ${target_file})${EXT}"
 done

--- a/infra/release-build.sh
+++ b/infra/release-build.sh
@@ -71,6 +71,7 @@ sign_and_notarize_binary () {
   return
 }
 
+EXT=
 case "${OS}" in
 macos)
   TARGETS=(
@@ -88,6 +89,7 @@ windows)
   TARGETS=(
     //cmd/engflow_auth:engflow_auth_windows_x64
   )
+  EXT=.exe
   ;;
 esac
 
@@ -104,5 +106,5 @@ trap uninstall_cert EXIT
 for target in "${TARGETS[@]}"; do
   target_file=$(bazel cquery --output=files "${target}")
   sign_and_notarize_binary "${target_file}"
-  cp "${target_file}" _out/
+  cp "${target_file}" "_out/${target_file}${EXT}"
 done

--- a/infra/release-check.sh
+++ b/infra/release-check.sh
@@ -22,8 +22,10 @@ if [[ -z "${RELEASE_VERSION:-}" ]]; then
   exit 1
 fi
 
-# Taken from https://semver.org/, with a `v` prepended
-readonly SEMVER_REGEX='^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-((0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$'
+# Taken from https://semver.org/,
+# prepended 'v', required by Go;
+# replaced \d with [0-9] for compatibility with grep regex flavor.
+readonly SEMVER_REGEX='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$'
 
 # Supplied version string must follow semver
 if ! grep --quiet --extended-regexp "${SEMVER_REGEX}" <<<${RELEASE_VERSION}; then


### PR DESCRIPTION
Set uploaded artifact names uniquely so that different jobs upload separate artifacts. The default was to overwrite the same artifact. No such setting is needed for downloading: the default is to download all artifacts.

Fixed the regular expression used to validate semantic versions. We used a PCRE-compatible regex from semver.org, but grep doesn't use PCRE, and different versions of grep (on Linux and macOS at least) interpret the same expression differently. Hopefully we've landed on something that works.

Added an .exe extension to the Windows artifact.