### PR TITLE
REC-110: don't use keyring when an unencrypted file token is present

### DIFF
--- a/internal/oauthtoken/fake.go
+++ b/internal/oauthtoken/fake.go
@@ -28,6 +28,7 @@ import (
 type FakeTokenStore struct {
 	Tokens                       map[string]*oauth2.Token
 	LoadErr, StoreErr, DeleteErr error
+	PanicValue                   any
 }
 
 var _ LoadStorer = (*FakeTokenStore)(nil)
@@ -39,6 +40,9 @@ func NewFakeTokenStore() *FakeTokenStore {
 }
 
 func (f *FakeTokenStore) Load(cluster string) (*oauth2.Token, error) {
+	if f.PanicValue != nil {
+		panic(f.PanicValue)
+	}
 	if f.LoadErr != nil {
 		return nil, f.LoadErr
 	}
@@ -50,6 +54,9 @@ func (f *FakeTokenStore) Load(cluster string) (*oauth2.Token, error) {
 }
 
 func (f *FakeTokenStore) Store(cluster string, token *oauth2.Token) error {
+	if f.PanicValue != nil {
+		panic(f.PanicValue)
+	}
 	if f.StoreErr != nil {
 		return f.StoreErr
 	}
@@ -58,6 +65,9 @@ func (f *FakeTokenStore) Store(cluster string, token *oauth2.Token) error {
 }
 
 func (f *FakeTokenStore) Delete(cluster string) error {
+	if f.PanicValue != nil {
+		panic(f.PanicValue)
+	}
 	if f.DeleteErr != nil {
 		return f.DeleteErr
 	}
@@ -89,6 +99,11 @@ func (f *FakeTokenStore) WithStoreErr(err error) *FakeTokenStore {
 
 func (f *FakeTokenStore) WithDeleteErr(err error) *FakeTokenStore {
 	f.DeleteErr = err
+	return f
+}
+
+func (f *FakeTokenStore) WithPanic(value any) *FakeTokenStore {
+	f.PanicValue = value
 	return f
 }
 

--- a/internal/oauthtoken/fake.go
+++ b/internal/oauthtoken/fake.go
@@ -26,9 +26,14 @@ import (
 // FakeTokenStore is a test implementation of LoadStorer that stores tokens in
 // memory instead of the system keychain.
 type FakeTokenStore struct {
-	Tokens                       map[string]*oauth2.Token
+	Tokens map[string]*oauth2.Token
+
+	// Error values to be returned by Load, Store, and Delete, if not nil.
 	LoadErr, StoreErr, DeleteErr error
-	PanicValue                   any
+
+	// Value to panic with in Load, Store, and Delete, if not nil.
+	// Used to test that a method is NOT called.
+	PanicValue any
 }
 
 var _ LoadStorer = (*FakeTokenStore)(nil)


### PR DESCRIPTION
On Linux, the keyring library can prompt the user for a password if it's not automatically unlocked. This causes engflow_auth to hang when invoked as a credential helper because neither stdin nor stdout are connected to a terminal.

With this change, the get command (and anything else that calls loadToken) now checks for a token created with -store=file first, then falls back to the keyring library if that's not present. This reverses the previous order.

When storing a token into the keyring, storeToken now deletes the token created with -store=file, if present, preventing it from taking precedence.

Together, these changes that mean when -store=file is used, the keyring library should only be used by the logout command, which attempts to delete both tokens.