### PR TITLE
Add version information to windows binaries

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,9 +5,9 @@ build --incompatible_strict_action_env
 
 # The {linux,macos,windows} configs are automatically enabled by Bazel depending
 # on the current platform due to --enable_platform_specific_config above.
-# Currently, there is no Windows support for building with bazel.
 build:linux --workspace_status_command=infra/get_workspace_status
 build:macos --workspace_status_command=infra/get_workspace_status
+build:windows --workspace_status_command=infra/get_workspace_status.cmd
 
 test --test_summary=testcase
 test --test_output=errors

--- a/infra/get_workspace_status.cmd
+++ b/infra/get_workspace_status.cmd
@@ -1,0 +1,39 @@
+:: Copyright 2024 EngFlow Inc. All rights reserved.
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+::
+::    http://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+
+:: The variables defined here are available not only in BES logs, but also for
+:: stamping into built binaries (version information, etc.). Removing vars or
+:: changing var names may break these version stamping libraries; if this script
+:: is updated, also make sure the following are up-to-date:
+::
+:: - //internal/buildstamp/BUILD
+
+@echo off
+
+for /F %%x in ('git rev-parse --abbrev-ref HEAD') do echo BUILD_SCM_BRANCH %%x
+for /F %%x in ('git rev-parse --verify HEAD') do echo BUILD_SCM_REVISION %%x
+
+echo STABLE_BUILD_RELEASE_VERSION %BUILD_RELEASE_VERSION%
+
+git diff-index --quiet HEAD --
+if %ERRORLEVEL% == 0 (
+  echo BUILD_SCM_STATUS "clean"
+) else (
+  echo BUILD_SCM_STATUS "modified"
+)
+
+for /F %%x in ('git remote get-url origin') do set REMOTE_URL=%%x
+if %ERRORLEVEL% == 0 (
+  echo BUILD_SCM_REMOTE %REMOTE_URL%
+)

--- a/infra/internal/check_copyright_headers/main.go
+++ b/infra/internal/check_copyright_headers/main.go
@@ -43,7 +43,7 @@ var (
 		regexp.MustCompile(`^platform/linux_x64/builtin_include_directory_paths`),
 		regexp.MustCompile(`^platform/linux_x64/module.modulemap`),
 	}
-	copyrightRegexp = regexp.MustCompile(`^(#|//) Copyright [0-9-]+ EngFlow Inc\.`)
+	copyrightRegexp = regexp.MustCompile(`^(#|//|::) Copyright [0-9-]+ EngFlow Inc\.`)
 )
 
 type checkerFunc func(string) bool


### PR DESCRIPTION
The information required for stamping binaries is only available when building
on Linux and macOS. Therefore, the windows binary doesn't show the version with
the `version` command:
```
> engflow_auth.exe version
build metadata is unavailable (build with bazel's `--stamp` flag to enable)
```

This change adds the windows batch file to collect the required information on
Windows systems.
