### PR TITLE
Fix build info for windows binary

### DIFF
--- a/infra/get_workspace_status.cmd
+++ b/infra/get_workspace_status.cmd
@@ -28,9 +28,9 @@ echo STABLE_BUILD_RELEASE_VERSION %BUILD_RELEASE_VERSION%
 
 git diff-index --quiet HEAD --
 if %ERRORLEVEL% == 0 (
-  echo BUILD_SCM_STATUS "clean"
+  echo BUILD_SCM_STATUS clean
 ) else (
-  echo BUILD_SCM_STATUS "modified"
+  echo BUILD_SCM_STATUS modified
 )
 
 for /F %%x in ('git remote get-url origin') do set REMOTE_URL=%%x


### PR DESCRIPTION
Putting the build status string into quotes won't match the check and
thus never report a clean / official build.
