### PR TITLE
REC-195: recommend -store=file when keyring is not available

### DIFF
--- a/cmd/engflow_auth/main.go
+++ b/cmd/engflow_auth/main.go
@@ -191,6 +191,11 @@ func (r *appState) import_(cliCtx *cli.Context) error {
 		storeURLs = append(storeURLs, clusterURL)
 	}
 
+	// Check early if the keyring works.
+	if err := r.testKeyringBeforeStore(storeURLs[0].Host); err != nil {
+		return err
+	}
+
 	var storeErrs []error
 	for _, storeURL := range storeURLs {
 		if err := r.storeToken(storeURL.Host, token.Token); err != nil {
@@ -227,6 +232,11 @@ func (r *appState) login(cliCtx *cli.Context) error {
 		return autherr.CodedErrorf(autherr.CodeBadParams, "invalid cluster: %w", err)
 	}
 	oauthURL := oauthEndpoint(clusterURL)
+
+	// Check early if the keyring works.
+	if err := r.testKeyringBeforeStore(clusterURL.Host); err != nil {
+		return err
+	}
 
 	// Tokens fetched during the process will be associated with each URL in
 	// storeURLs in the token store

--- a/cmd/engflow_auth/main_test.go
+++ b/cmd/engflow_auth/main_test.go
@@ -373,6 +373,20 @@ func TestRun(t *testing.T) {
 			wantErr:  "fetch_token_fail",
 		},
 		{
+			desc: "login token load failure",
+			args: []string{"login", "cluster.example.com"},
+			authenticator: &fakeAuth{
+				deviceResponse: &oauth2.DeviceAuthResponse{
+					VerificationURIComplete: "https://cluster.example.com/with/auth/code",
+				},
+			},
+			keyringStore: &oauthtoken.FakeTokenStore{
+				LoadErr: errors.New("token_load_fail"),
+			},
+			wantCode: autherr.CodeTokenStoreFailure,
+			wantErr:  "-store=file", // error message recommends -store=file
+		},
+		{
 			desc: "login token store failure",
 			args: []string{"login", "cluster.example.com"},
 			authenticator: &fakeAuth{
@@ -627,6 +641,15 @@ func TestRun(t *testing.T) {
 			args:         []string{"import", "-store=file"},
 			machineInput: strings.NewReader(`{"token":{"access_token":"token_data"},"cluster_host":"cluster.example.com"}`),
 			keyringStore: oauthtoken.NewFakeTokenStore().WithPanic("do not call"),
+		},
+		{
+			desc: "import with keyring load failure",
+			args: []string{"login", "cluster.example.com"},
+			keyringStore: &oauthtoken.FakeTokenStore{
+				LoadErr: errors.New("token_load_fail"),
+			},
+			wantCode: autherr.CodeTokenStoreFailure,
+			wantErr:  "-store=file", // error message recommends -store=file
 		},
 	}
 	for _, tc := range testCases {

--- a/internal/oauthtoken/fake.go
+++ b/internal/oauthtoken/fake.go
@@ -15,6 +15,7 @@
 package oauthtoken
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"time"
@@ -53,7 +54,7 @@ func (f *FakeTokenStore) Load(cluster string) (*oauth2.Token, error) {
 	}
 	token, ok := f.Tokens[cluster]
 	if !ok {
-		return nil, fmt.Errorf("%s: token not found", cluster)
+		return nil, &tokenNotFoundError{cluster: cluster}
 	}
 	return token, nil
 }
@@ -132,4 +133,16 @@ func NewFakeTokenForSubject(subject string) *oauth2.Token {
 		TokenType:   "Bearer",
 		Expiry:      expiry,
 	}
+}
+
+type tokenNotFoundError struct {
+	cluster string
+}
+
+func (e *tokenNotFoundError) Error() string {
+	return fmt.Sprintf("%s: token not found", e.cluster)
+}
+
+func (e *tokenNotFoundError) Is(err error) bool {
+	return errors.Is(err, fs.ErrNotExist)
 }


### PR DESCRIPTION
In the login and import commands, test if we can load a token from
the keyring before doing anything. If the keyring is not available,
print a message that recommends -store=file.

Previously, we could go through the whole login flow then fail to
store the token. This was frustrating for the user since it wasn't
clear what to do next (keyring errors are obscure), and once they
figure it out, then have to go through the login flow again.
