### PR TITLE
engflow_auth: add --insecure flag to "login"

### DIFF
--- a/cmd/engflow_auth/main.go
+++ b/cmd/engflow_auth/main.go
@@ -227,6 +227,7 @@ func (r *appState) login(cliCtx *cli.Context) error {
 	ctx := cliCtx.Context
 
 	if cliCtx.Bool("insecure") {
+		fmt.Fprintf(cliCtx.App.ErrWriter, "Warning: server TLS validation is disabled\n")
 		httpClient := &http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{

--- a/cmd/engflow_auth/main.go
+++ b/cmd/engflow_auth/main.go
@@ -16,12 +16,14 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
@@ -224,6 +226,17 @@ func (r *appState) import_(cliCtx *cli.Context) error {
 func (r *appState) login(cliCtx *cli.Context) error {
 	ctx := cliCtx.Context
 
+	if cliCtx.Bool("insecure") {
+		httpClient := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+			},
+		}
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
+	}
+
 	if cliCtx.NArg() != 1 {
 		return autherr.CodedErrorf(autherr.CodeBadParams, "expected exactly 1 positional argument, a cluster name")
 	}
@@ -349,6 +362,10 @@ func makeApp(root *appState) *cli.App {
 		Name:  "alias",
 		Usage: "Comma-separated list of alias hostnames for this cluster",
 	}
+	insecureFlag := &cli.BoolFlag{
+		Name:  "insecure",
+		Usage: "Disable server TLS validation",
+	}
 
 	app := &cli.App{
 		Name:  "engflow_auth",
@@ -386,7 +403,7 @@ credential helper protocol.`),
 Initiates an interactive OAuth2 flow to log into the cluster at
 CLUSTER_URL.`),
 				Action: root.login,
-				Flags:  []cli.Flag{aliasFlag, storeFlag},
+				Flags:  []cli.Flag{aliasFlag, storeFlag, insecureFlag},
 			},
 			{
 				Name:      "logout",


### PR DESCRIPTION
If set, then disable server TLS validation. Can be used for testing.